### PR TITLE
Re-implement onPermissionsChecked method

### DIFF
--- a/app/src/main/java/com/cyb3rg0d/canvass/MainActivity.java
+++ b/app/src/main/java/com/cyb3rg0d/canvass/MainActivity.java
@@ -192,6 +192,9 @@ public class MainActivity extends AppCompatActivity {
                 .withPermissions(Manifest.permission.READ_EXTERNAL_STORAGE,Manifest.permission.WRITE_EXTERNAL_STORAGE)
                 .withListener(new MultiplePermissionsListener() {
                     @Override
+                    public void onPermissionsChecked(MultiplePermissionsReport multiplePermissionsReport) { }
+
+                    @Override
                     public void onPermissionRationaleShouldBeShown(List<PermissionRequest> list, PermissionToken permissionToken) {
                         permissionToken.continuePermissionRequest();
                     }


### PR DESCRIPTION
This pull request fixes an oversight I had in #4. The listener methods still have to be implemented even if there is nothing within them.

This fixes the build workflow from failing.